### PR TITLE
Disable duplication rules in tests

### DIFF
--- a/rules/test-overrides.js
+++ b/rules/test-overrides.js
@@ -19,7 +19,7 @@ module.exports = {
         'promise/always-return': 'off',
         'promise/no-callback-in-promise': 'off',
         'sonarjs/no-duplicate-string': 'off',
-        'sonarjs/no-identical-functions': 'off'
+        'sonarjs/no-identical-functions': 'off',
       },
     },
   ],

--- a/rules/test-overrides.js
+++ b/rules/test-overrides.js
@@ -18,6 +18,8 @@ module.exports = {
         'max-statements': 'off',
         'promise/always-return': 'off',
         'promise/no-callback-in-promise': 'off',
+        'sonarjs/no-duplicate-string': 'off',
+        'sonarjs/no-identical-functions': 'off'
       },
     },
   ],


### PR DESCRIPTION
Test files usually contain multiple blocks with repeated text and function in different scenarios.