### PR TITLE
Comment out debugging logs

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,11 @@
 const checkMissing = require('./lib/missing')
-const showLoaded = require('./lib/loaded')
+// const showLoaded = require('./lib/loaded')
 const { rules, extraInstallPackage } = require('./configs')
 
 // Workaround VS Code trying to run this file twice!
 if (!global.hasAdjunctLoaded) {
   checkMissing(rules, extraInstallPackage)
-  showLoaded(rules, [])
+  // showLoaded(rules, [])
 
   // Disable some rules in unit tests
   rules.push('test-overrides')


### PR DESCRIPTION
This closes #46 by commenting out the logging portion.  Not sure how to access the `quiet` flag here - perhaps there's some magic that can be done to get the console command (and thus the flags) which executed this code?