### PR TITLE
Fixes #51 - Move snyk to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adjunct",
-  "version": "4.11.1",
+  "version": "4.11.0",
   "author": "David J. Bradshaw",
   "license": "MIT",
   "description": "A reasonable collection of plugins to use alongside your main esLint configuration",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-adjunct",
-  "version": "4.11.0",
+  "version": "4.11.1",
   "author": "David J. Bradshaw",
   "license": "MIT",
   "description": "A reasonable collection of plugins to use alongside your main esLint configuration",

--- a/package.json
+++ b/package.json
@@ -32,10 +32,10 @@
     "mkdirp": "^1.0.4",
     "ramda": "^0.27.1",
     "read-pkg-up": "^8.0.0",
-    "rimraf": "^3.0.2",
-    "snyk": "^1.486.0"
+    "rimraf": "^3.0.2"
   },
   "devDependencies": {
+    "snyk": "^1.486.0",
     "@testing-library/dom": "^7.30.0",
     "@testing-library/jest-dom": "^5.11.9",
     "@typescript-eslint/eslint-plugin": "^4.17.0",


### PR DESCRIPTION
PR for Issue #51 

`snyk` package is moved from dependencies to `devDependencies`